### PR TITLE
make installation of ruby gems optional

### DIFF
--- a/manifests/authorization.pp
+++ b/manifests/authorization.pp
@@ -1,4 +1,4 @@
-# == Class: managedmac::authorization
+# == Class: macauthdb::authorization
 #
 # Controls various system authorization keys, granting users access to system
 # resources otherwise only accessible by administrators.
@@ -26,7 +26,7 @@
 #   Type: Bool
 #
 # [*allow_dvd_setregion_initial*]
-#   Allow 'everyone' to set the inital DVD region code, true or false.
+#   Allow 'everyone' to set the initial DVD region code, true or false.
 #   Default: false
 #   Type: Bool
 #
@@ -41,19 +41,19 @@
 #
 # # Example: defaults.yaml
 # ---
-# managedmac::authorization::allow_energysaver true
-# managedmac::authorization::allow_datetime true
-# managedmac::authorization::allow_timemachine true
+# macauthdb::authorization::allow_energysaver true
+# macauthdb::authorization::allow_datetime true
+# macauthdb::authorization::allow_timemachine true
 #
 # Then simply, create a manifest and include the class...
 #
 #  # Example: my_manifest.pp
-#  include managedmac::authorization
+#  include macauthdb::authorization
 #
 # If you just wish to test the functionality of this class, you could also do
 # something along these lines:
 #
-#  class { 'managedmac::authorization':
+#  class { 'macauthdb::authorization':
 #    allow_energysaver => true,
 #    allow_datetime    => true,
 #    allow_timemachine => true,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,4 +1,4 @@
-# == Class: managedmac
+# == Class: macauthdb
 #
 # Module initializer.
 #
@@ -19,9 +19,9 @@
 #
 # === Examples
 #
-#  include managedmac
+#  include macauthdb
 #
-#  class { managedmac: }
+#  class { macauthdb: }
 #
 # === Authors
 #

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,24 +1,28 @@
-#
+# Class to install required Ruby Gems for macauthdb
 class macauthdb::install (
+  $install_gems = $macauthdb::params::install_gems,
   $sqlite_manage = $macauthdb::params::sqlite_manage,
   $cfpropertylist_manage = $macauthdb::params::cfpropertylist_manage,
   $sqlite_pkgname = $macauthdb::params::sqlite_pkgname,
   $sqlite_version = $macauthdb::params::sqlite_version,
 ) inherits macauthdb {
 
-  if $sqlite_manage {
-    package { $sqlite_pkgname:
-      ensure   => $sqlite_version,
-      provider => 'puppet_gem',
+  validate_bool ($install_gems)
+
+  if $install_gems == true {
+    if $sqlite_manage {
+      package { $sqlite_pkgname:
+        ensure   => $sqlite_version,
+        provider => 'puppet_gem',
+      }
+    }
+
+    if $cfpropertylist_manage {
+      package { 'CFPropertyList':
+        ensure   => '2.3.2',
+        provider => 'puppet_gem',
+      }
     }
   }
-
-  if $cfpropertylist_manage {
-    package { 'CFPropertyList':
-      ensure   => '2.3.2',
-      provider => 'puppet_gem',
-    }
-  }
-
 }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,5 +1,9 @@
-#
-class macauthdb::params {
+# Parameters class for macauthdb
+class macauthdb::params (
+
+  $install_gems = true,
+
+){
 
   $sqlite_manage = $::osfamily ? {
     'Darwin' => true,


### PR DESCRIPTION
``` yaml
macauthdb::params::install_gems: false
```

I'm already managing these gems plus a few others in another manifest. As such, puppet will see them as a duplicate declaration. This PR gives a method to disable the installation of the ruby gems from this module. 
